### PR TITLE
Set standards kiwi module and add missing modules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-python-kiwi
+kiwi
+kiwi-boxed-plugin
 typing-extensions
 lxml
 inquirer
+pytest


### PR DESCRIPTION
- python-kiwi does not exist in pypi
- add missing module : kiwi-boxed-plugin
- add pytest for unit testing 