### PR TITLE
Add reponame check if not defined

### DIFF
--- a/src/berry_mill/kiwrap.py
+++ b/src/berry_mill/kiwrap.py
@@ -81,23 +81,28 @@ class KiwiBuilder:
         """
         Add a repository for the builder
         """
-        repodata.setdefault("key", "file://" + self._get_repokeys(reponame, repodata))
-        self._check_repokey(repodata, reponame)
-        self._repos[reponame] = repodata
+        if reponame:
+            repodata.setdefault("key", "file://" + self._get_repokeys(reponame, repodata))
+            self._check_repokey(repodata, reponame)
+            self._repos[reponame] = repodata
+        else:
+            print("Repository name not defined")
+            sys.exit(1)
+        
         return self
 
-    def _get_repokeys(self, reponame, repodata:Dict[str, str]) -> str:
+    def _get_repokeys(self, reponame: str, repodata:Dict[str, str]) -> str:
         """
         Download repository keys to a temporary directory
         """
-        url = urlparse(repodata["url"])
+        url: ParseResult = urlparse(repodata["url"])
         g_path:str = f"{self._tmpdir}/{reponame}_release.key"
         if repodata.get("components", "/") != "/":
-            s_url = f"{url.scheme}://{url.netloc}{os.path.join(url.path, 'dists', repodata['name'])}"
+            s_url: str = f"{url.scheme}://{url.netloc}{os.path.join(url.path, 'dists', repodata['name'])}"
             # TODO: grab standard keys
             g_path = ""
         else:
-            s_url = f"{url.scheme}://{url.netloc}{os.path.join(url.path, 'Release.key')}"
+            s_url: str = f"{url.scheme}://{url.netloc}{os.path.join(url.path, 'Release.key')}"
             response = requests.get(s_url, allow_redirects=True)
             with open(g_path, "wb") as f_rel:
                 f_rel.write(response.content)


### PR DESCRIPTION
This use case should not happen as it's a dict and will complain about a ":" that hanging alone if reponame is not defined .
However from unit testing point of view , this case is not covered .
What do you think , add it or leave it as it is ? 