### PR TITLE
Add sysroot prepare support 

### DIFF
--- a/config/berrymill.conf.example
+++ b/config/berrymill.conf.example
@@ -1,6 +1,3 @@
-# OBS API server. Default is http://api.opensuse.org
-obs-api: https://ebs.ebgroup.elektrobit.com
-
 # Global repositories will not be added, if set to "false"
 use-global-repos: false
 
@@ -11,7 +8,6 @@ repos:
   release:
     # Architecture
     # Conforms to Debian standard: https://wiki.debian.org/SupportedArchitectures
-
     amd64:
      # Just an alias of the repo, free form
       Ubuntu-Jammy:
@@ -19,18 +15,25 @@ repos:
         url: http://ftp.halifax.rwth-aachen.de/ubuntu/
         type: apt-deb
         key: file:///usr/lib/example/gnupg/keys/build_key_ubuntu_jammy.gpg
+        # Example key file
+        # key: file:///example/directory/with/key/build_key_ubuntu_jammy.gpg
 
         # Distro name
         name: jammy
         components: main,universe,multiverse,restricted
       Your-Repo-Alias:
         url: http://foo.com/bar/repo
+      Corbos-Linux:
+        url: http://linux.elektrobit.com/corbos
         type: apt-deb
+        key: file:///usr/share/keyrings/repo_eb_gm.pub.gpg
+
+        name: corbos
+        components: testing
 
         # no "key" defined -> berrymill will try and look for key
         # Currently automatic lookup online only works if your Repo is a flat repo and does not have components
         # Otherwise berrymill will prompt you with a selection of your trusted keys in (/etc/apt/trusted.gpg.d)
-
         # no "name" defined, therefore repo format is flat
         # no "compoments" defined, therefore repo format is flat
 
@@ -39,6 +42,21 @@ repos:
       Your-Arm-Repo-Alias:
         # no "compoments" defined, therefore repo format is flat
         url: http://foo-arm.com/bar-arm/repo
+      Ubuntu-Jammy:
+        url: http://ports.ubuntu.com/
         type: apt-deb
         key: file:///usr/lib/nautilos/gnupg/keys/build_key_nautilos_2.0_devel.asc
         trusted: true
+        # Example key file
+        # key: file:///example/directory/with/key/build_key_ubuntu_ports_jammy.gpg
+
+        name: jammy
+        components: main,universe,multiverse,restricted
+
+      Corbos-Linux:
+        url: http://linux.elektrobit.com/corbos
+        type: apt-deb
+        key: file:///usr/share/keyrings/repo_eb_gm.pub.gpg
+
+        name: corbos
+        components: testing

--- a/src/berry_mill/builder.py
+++ b/src/berry_mill/builder.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from typing import List
+from typing_extensions import Unpack
+from lxml import etree
+import os
+import sys
+import shutil
+import tempfile
+
+from urllib.parse import urlparse, quote
+from typing import Dict
+from berry_mill.kiwiapp import KiwiAppLocal, KiwiAppBox
+from kiwi.kiwi import KiwiError
+from platform import machine
+from berry_mill.kiwrap import KiwiParent
+
+from berry_mill.params import KiwiBuildParams, KiwiParams
+
+
+
+class KiwiBuilder(KiwiParent):
+    """
+    Kiwi wrapper for appliance builder.
+    """
+    # TODO handle TypeError
+    def __init__(self, descr:str, **kw: Unpack[KiwiBuildParams]):
+        self._params:Dict[KiwiBuildParams] = kw
+        
+        super().__init__(descr=descr,
+                        profile=self._params.get("profile"),
+                        debug=self._params.get("debug", False))
+
+        if self._params.get("target_dir"):
+            self._params["target_dir"] = self._params["target_dir"].rstrip("/")
+
+        self._boxrootdir:str = os.path.join(self._appliance_path, "boxroot")
+        print(self._boxrootdir)
+        self._fcleanbox:bool = False
+        # tmp boxroot dir only needed when build mode is not local
+        if not self._params.get("local", False):
+            boxdir:str = os.path.join(self._appliance_path, "boxroot")
+            if not os.path.exists(boxdir):
+                # flag for cleanup to remember to also delete boxroot dir if
+                # it hasnt existed before already
+                self._fcleanbox = True
+                os.makedirs(boxdir)
+
+            self._boxtmpkeydir:str = tempfile.mkdtemp(prefix="berrymill-keys-", dir= self._boxrootdir)
+
+            self._boxtmpargdir:str = tempfile.mkdtemp(prefix="berrymill-args-", dir= self._boxrootdir)
+
+
+    def _get_relative_file_uri(self, repo_key_path) -> str:
+        """
+        Change the file:// URIs in the repo key values to be relative to the boxroot
+        """
+        if not self._boxtmpkeydir:
+            raise Exception("Key directory not available")
+        if not repo_key_path:
+            raise Exception("Key path not defined")
+        return "file:///" + \
+               quote( \
+               os.path.join( \
+               os.path.basename(self._boxtmpkeydir), os.path.basename(repo_key_path)))
+
+
+    def _write_repokeys_box(self, repos:Dict[str, Dict[str, str]]) -> None:
+        """
+        Write repo keys from the self._tmp dir to the boxroot, so kiwi box can access the keys
+        It expects a file:// uri to be present in repos[reponame][key]
+        """
+        dst = self._boxtmpkeydir
+        if not dst:
+            raise Exception("ERROR: Boxroot directory is not defined")
+
+        for reponame in repos:
+            k = repos.get(reponame, {}).get("key")
+            parsed_url = urlparse(k)
+            try:
+                shutil.copy(parsed_url.path, dst)
+            except Exception as exc:
+                print(f"ERROR: Failure while trying to copying the keyfile at {parsed_url.path}")
+                print(exc)
+                return
+            repos.get(reponame, {})["key"] = self._get_relative_file_uri(parsed_url.path)
+
+    def process(self) -> None:
+        """
+        Run builder. It supposed to be already within that directory (os.chdir).
+        Directory is changed by the parent caller of the KiwiBuilder class.
+        """
+        # options that are solely accepted by kiwi-ng
+        kiwi_options = self._kiwi_options
+        # options, solely accepted by box-build plugin
+        box_options:List[str] = ["--box","ubuntu"]
+
+        if self._kiwiparams.get("debug", False):
+            box_options.append("--box-debug")
+
+        if self._params.get("cpu"):
+            box_options = ["--cpu", self._params.get("cpu")] + box_options
+
+        if self._params.get("box_memory"):
+            box_options += ["--box-memory", self._params.get("box_memory")]
+
+        if machine() == "aarch64":
+            box_options += ["--machine", "virt"]
+
+        allow_no_accel:bool = True
+        # TODO: When using cross, e.g. cpu param needs to be disabled
+        if self._params.get("cross") and machine() == "x86_64":
+            box_options += ["--aarch64", "--cpu", "cortex-a57", "--machine", "virt", "--no-accel"]
+            kiwi_options += ["--target-arch", "aarch64"]
+            allow_no_accel = False
+
+        if self._params.get("accel", False) and allow_no_accel:
+            box_options.append("--no-accel")
+
+        try:
+            config_tree = etree.parse(f"{self._appliance_descr}")
+        except Exception as err:
+            print("ERROR: Failure {} while parsing appliance description".format(err))
+            return
+
+        try:
+            image_name:list = config_tree.xpath("//image/@name")
+        except Exception as err:
+            print("ERROR: Failure {} while trying to extract image name", err)
+            return
+
+        target_dir = os.path.join(
+            self._params.get("target_dir","/tmp"),\
+            f"{image_name[0]}.{self._kiwiparams.get('profile', '')}")
+
+        if self._params.get("clean", False):
+            clean_target = target_dir
+            if self._params.get("profile"):
+                clean_target += f".{self._params.get('profile')}"
+            if self._params.get("local", False):
+                shutil.rmtree(clean_target)
+
+        if not self._params.get("local", False):
+            self._write_repokeys_box(self._repos)
+
+        if self._params.get("local", False):
+            command = ["kiwi-ng"] + kiwi_options\
+                    + ["system", "build", "--description", "."]\
+                    + ["--target-dir", target_dir] 
+
+            try:
+                print("Starting Kiwi for local build")                
+                KiwiAppLocal(command, repos=self._repos).run()
+            except KiwiError as kiwierr:
+                print("KiwiError:", type(kiwierr).__name__)
+                print(kiwierr)
+                return
+        else:
+            command = ["kiwi-ng"]+ kiwi_options\
+                    + ["system", "boxbuild"] + box_options\
+                    + ["--", "--description", '.'] + ["--target-dir", target_dir]\
+
+            try:
+                print("Starting Kiwi Box")
+                KiwiAppBox(command, repos=self._repos, args_tmp_dir=self._boxtmpargdir).run()
+            except KiwiError as kiwierr:
+                print("KiwiError:", type(kiwierr).__name__)
+                print(kiwierr)
+                return
+
+        # run kiwi here with "appliance_init" which is a ".kiwi" file
+        os.system("ls -lah")
+
+        print(self._repos)
+
+
+
+    def cleanup(self) -> None:
+        """
+        Cleanup the environment after the build
+        """
+        super().cleanup()
+        if not self._initialized:
+            print("Cleanup finished")
+            return
+        try:
+            if not self._params.get("local", False):
+                if os.path.exists(self._boxtmpkeydir):
+                    shutil.rmtree(self._boxtmpkeydir)
+                if os.path.exists(self._boxtmpargdir):
+                    shutil.rmtree(self._boxtmpargdir)
+                if self._fcleanbox:
+                    # if Flag fcleanbox is true an empty boxroot is guranteed to exist
+                    shutil.rmtree(os.path.join(self._appliance_path, "boxroot"))
+        except Exception as e:
+            print(f"Error: Cleanup Failed : {e}")
+
+        print("Cleanup finished")

--- a/src/berry_mill/kiwiapp.py
+++ b/src/berry_mill/kiwiapp.py
@@ -2,9 +2,10 @@ import os
 import sys
 from typing import Dict, List
 from abc import ABC, abstractmethod
-from berry_mill.boxbuild import BoxBuildTask
 
+from berry_mill.boxbuild import BoxBuildTask
 from berry_mill.localwrap import LocalBuildTask
+from berry_mill.preparetask import PrepareTask
 
 class KiwiApp(ABC):
     """
@@ -19,6 +20,14 @@ class KiwiApp(ABC):
     @abstractmethod    
     def run(self) -> None:
         pass
+
+class KiwiAppPrepare(KiwiApp):
+
+    def __init__(self, argv:List[str], repos:Dict[str, Dict[str,str]]):
+        super().__init__(argv, repos)
+    
+    def run(self) -> None:
+        PrepareTask(self._repos).process()
 
 
 class KiwiAppLocal(KiwiApp):

--- a/src/berry_mill/kiwrap.py
+++ b/src/berry_mill/kiwrap.py
@@ -1,83 +1,75 @@
 from __future__ import annotations
+from abc import abstractmethod
 
-from typing import List, Set
-from typing import TypedDict
+from typing import List
 from typing_extensions import Unpack
-from lxml import etree
 import os
 import sys
 import shutil
 import tempfile
 import requests
 import inquirer
-
-from urllib.parse import ParseResult, urlparse, quote
+from lxml import etree
+from urllib.parse import ParseResult, urlparse
 from typing import Dict
-from berry_mill.kiwiapp import KiwiAppLocal, KiwiAppBox
-from kiwi.kiwi import KiwiError
-from platform import machine
 
-class KiwiParams(TypedDict):
-    """
-    Dictionary for Kiwi Parameters
-
-    Attributes:
-
-        profile (str, Optional): select profile for images that makes use of it.
-        box_memory (str, Default: 8G): specify main memory to use for the QEMU VM (box).
-        debug (bool, Default: False): run in debug mode. This means the box VM stays open and the kiwi log level is set to debug(10).
-        clean (bool, Default: False): cleanup previous build results prior build.
-        cross (bool, Default: False): cross image build on x86_64 to aarch64 target.
-        cpu (str, Optional): cpu to use for the QEMU VM (box)
-        local (bool, Default: False): run build process locally on this machine. Requires sudo setup and installed KIWI toolchain.
-        target_dir (str, Default:/tmp/IMAGE_NAME[.PROFILE_NAME]): store image results in given dirpath.
-    """
-    profile: str
-    box_memory: str
-    debug: bool
-    clean: bool
-    cross: bool
-    cpu: str
-    local: bool
-    target_dir: str
+from berry_mill.params import KiwiParams
 
 
-class KiwiBuilder:
-    """
-    Kiwi wrapper for appliance builder.
-    """
-    # TODO handle TypeError
-    def __init__(self, descr:str, **kw: Unpack[KiwiParams]):
+class KiwiParent:
+    def __init__(self, descr:str, **pkw: Unpack[KiwiParams]):
         self._repos:Dict[str, Dict[str, str]] = {}
         self._appliance_path:str = os.getcwd()
-        print(self._appliance_path)
         self._appliance_descr:str = descr
-        self._params:Dict[KiwiParams] = kw
-
-        if self._params.get("target_dir"):
-            self._params["target_dir"] = self._params["target_dir"].rstrip("/")
 
         self._trusted_gpg_d:str = "/etc/apt/trusted.gpg.d"
 
         self._tmpdir:str = tempfile.mkdtemp(prefix="berrymill-keys-", dir="/tmp")
 
-        self._boxrootdir:str = os.path.join(self._appliance_path, "boxroot")
-        print(self._boxrootdir)
-        self._fcleanbox:bool = False
-        # tmp boxroot dir only needed when build mode is not local
-        if not self._params.get("local", False):
-            boxdir:str = os.path.join(self._appliance_path, "boxroot")
-            if not os.path.exists(boxdir):
-                # flag for cleanup to remember to also delete boxroot dir if
-                # it hasnt existed before already
-                self._fcleanbox = True
-                os.makedirs(boxdir)
+        self._kiwiparams:Dict[KiwiParams] = pkw
 
-            self._boxtmpkeydir:str = tempfile.mkdtemp(prefix="berrymill-keys-", dir= self._boxrootdir)
+        self._kiwi_options:List[str] = []
 
-            self._boxtmpargdir:str = tempfile.mkdtemp(prefix="berrymill-args-", dir= self._boxrootdir)
+        self._initialized:bool = False
 
-    def add_repo(self, reponame:str, repodata:Dict[str, str]) -> KiwiBuilder:
+        if self._kiwiparams.get("debug", False):
+            self._kiwi_options.append("--debug")
+
+        print("Using appliance \"{}\" located at \"{}\"".format(self._appliance_descr, self._appliance_path))
+
+        try:
+            config_tree = etree.parse(f"{self._appliance_descr}")
+        except Exception as err:
+            print("ERROR: Failure {} while parsing appliance description".format(err))
+            sys.exit(1)
+
+        try:
+            profiles = config_tree.xpath("//profile/@name")
+        except Exception as err:
+            print("ERROR: Failure {} while trying to extract profile names", err)
+            self.cleanup()
+            sys.exit(1)
+
+
+        if not self._kiwiparams.get("profile") and profiles:
+            print("No Profile selected.")
+            print("Please select one of the available following profiles using --profile:")
+            print(profiles)
+            self.cleanup()
+            sys.exit(1)
+
+        if self._kiwiparams.get("profile"):
+            profile = self._kiwiparams.get("profile")
+            if profile in profiles:
+                self._kiwi_options += ["--profile", profile]
+            else:
+                self.cleanup()
+                print(f"\'{profile}\' is not a valid profile. Available: {profiles}")
+                sys.exit(1)
+
+        self._initialized = True
+    
+    def add_repo(self, reponame:str, repodata:Dict[str, str]) -> KiwiParent:
         """
         Add a repository for the builder
         """
@@ -87,6 +79,7 @@ class KiwiBuilder:
             self._repos[reponame] = repodata
         else:
             print("Repository name not defined")
+            self.cleanup()
             sys.exit(1)
 
         return self
@@ -117,21 +110,6 @@ class KiwiBuilder:
                 f_rel.write(response.content)
             response.close()
             return g_path
-
-
-    def _get_relative_file_uri(self, repo_key_path) -> str:
-        """
-        Change the file:// URIs in the repo key values to be relative to the boxroot
-        """
-        if not self._boxtmpkeydir:
-            raise Exception("Key directory not available")
-        if not repo_key_path:
-            raise Exception("Key path not defined")
-        return "file:///" + \
-               quote( \
-               os.path.join( \
-               os.path.basename(self._boxtmpkeydir), os.path.basename(repo_key_path)))
-
     def _check_repokey(self, repodata:Dict[str, str], reponame) -> None:
         if not repodata.get("key"):
             raise Exception("Path to the key is not defined")
@@ -151,48 +129,8 @@ class KiwiBuilder:
             else:
                 print("Trusted key not foud on system")
         if not os.path.exists(parsed_url.path):
-            self._cleanup()
+            self.cleanup()
             Exception(parsed_url.path + " does not exist" if parsed_url.path else f"key file path not specified for {reponame}")
-
-    def _write_repokeys_box(self, repos:Dict[str, Dict[str, str]]) -> None:
-        """
-        Write repo keys from the self._tmp dir to the boxroot, so kiwi box can access the keys
-        It expects a file:// uri to be present in repos[reponame][key]
-        """
-        dst = self._boxtmpkeydir
-        if not dst:
-            raise Exception("ERROR: Boxroot directory is not defined")
-
-        for reponame in repos:
-            k = repos.get(reponame, {}).get("key")
-            parsed_url = urlparse(k)
-            try:
-                shutil.copy(parsed_url.path, dst)
-            except Exception as exc:
-                print(f"ERROR: Failure while trying to copying the keyfile at {parsed_url.path}")
-                print(exc)
-                self._cleanup()
-                sys.exit(1)
-            repos.get(reponame, {})["key"] = self._get_relative_file_uri(parsed_url.path)
-
-
-    def _cleanup(self) -> None:
-        """
-        Cleanup the environment after the build
-        """
-        print("Cleaning up...")
-        try:
-            shutil.rmtree(self._tmpdir)
-            if not self._params.get("local", False):
-                shutil.rmtree(self._boxtmpkeydir)
-                shutil.rmtree(self._boxtmpargdir)
-                if self._fcleanbox:
-                    # if Flag fcleanbox is true an empty boxroot is guranteed to exist
-                    shutil.rmtree(os.path.join(self._appliance_path, "boxroot"))
-        except Exception as e:
-            print(f"Error: Cleanup Failed : {e}")
-
-        print("Cleanup finished")
 
     def _key_selection(self, reponame:str, options:List[str]) -> str | None:
         none_of_above = "none of the above"
@@ -208,112 +146,19 @@ class KiwiBuilder:
         print("You selected:", answer["choice"])
 
         return answer["choice"] != none_of_above and answer["choice"] or None
-
-
-    def build(self) -> None:
+    
+    def cleanup(self) -> None:
         """
-        Run builder. It supposed to be already within that directory (os.chdir).
-        Directory is changed by the parent caller of the KiwiBuilder class.
+        Cleanup the environment after the build
         """
-        print("Using appliance \"{}\" located at \"{}\"".format(self._appliance_descr, self._appliance_path))
-        # options that are solely accepted by kiwi-ng
-        kiwi_options = []
-        # options, solely accepted by box-build plugin
-        box_options:List[str] = ["--box","ubuntu"]
-
-        if self._params.get("debug", False):
-            kiwi_options.append("--debug")
-            box_options.append("--box-debug")
-
-        if self._params.get("cpu"):
-            box_options = ["--cpu", self._params.get("cpu")] + box_options
-
-        if self._params.get("box_memory"):
-            box_options += ["--box-memory", self._params.get("box_memory")]
-
-        if machine() == "aarch64":
-            box_options += ["--machine", "virt"]
-
-        # TODO: When using cross, e.g. cpu param needs to be disabled
-        if self._params.get("cross") and machine() == "x86_64":
-            box_options += ["--aarch64", "--cpu", "cortex-a57", "--machine", "virt", "--no-accel"]
-            kiwi_options += ["--target-arch", "aarch64"]
-
-
+        print("Cleaning up...")
         try:
-            config_tree = etree.parse(f"{self._appliance_descr}")
-        except Exception as err:
-            print("ERROR: Failure {} while parsing appliance description".format(err))
-            sys.exit(1)
+            shutil.rmtree(self._tmpdir)
+        except Exception as e:
+            print(f"Error: Cleanup Failed : {e}")
 
-        try:
-            image_name:list = config_tree.xpath("//image/@name")
-        except Exception as err:
-            print("ERROR: Failure {} while trying to extract image name", err)
-            sys.exit(1)
-
-        target_dir = os.path.join(
-            self._params.get("target_dir","/tmp"),\
-            f"{image_name[0]}.{self._params.get('profile', '')}")
-
-        profiles = config_tree.xpath("//profile/@name")
-
-        if not self._params.get("profile") and profiles:
-            print("No Profile selected.")
-            print("Please select one of the available following profiles using --profile:")
-            print(profiles)
-            self._cleanup()
-            sys.exit(1)
-
-        if self._params.get("profile"):
-            profile = self._params.get("profile")
-            if profile in profiles:
-                kiwi_options += ["--profile", profile]
-            else:
-                self._cleanup()
-                raise Exception(f"\'{profile}\' is not a valid profile. Available: {profiles}")
+    @abstractmethod
+    def process(self) -> None:
+        raise NotImplementedError()
 
 
-        if self._params.get("clean", False):
-            clean_target = target_dir
-            if self._params.get("profile"):
-                clean_target += f".{self._params.get('profile')}"
-            if self._params.get("local", False):
-                shutil.rmtree(clean_target)
-
-        if not self._params.get("local", False):
-            self._write_repokeys_box(self._repos)
-
-        if self._params.get("local", False):
-            command = ["kiwi-ng"] + kiwi_options\
-                    + ["system", "build", "--description", "."]\
-                    + ["--target-dir", target_dir] 
-
-            try:
-                print("Starting Kiwi for local build")                
-                KiwiAppLocal(command, repos=self._repos).run()
-            except KiwiError as kiwierr:
-                print("KiwiError:", type(kiwierr).__name__)
-                print(kiwierr)
-                self._cleanup()
-                sys.exit(1)
-        else:
-            command = ["kiwi-ng"]+ kiwi_options\
-                    + ["system", "boxbuild"] + box_options\
-                    + ["--", "--description", '.'] + ["--target-dir", target_dir]\
-
-            try:
-                print("Starting Kiwi Box")
-                KiwiAppBox(command, repos=self._repos, args_tmp_dir=self._boxtmpargdir).run()
-            except KiwiError as kiwierr:
-                print("KiwiError:", type(kiwierr).__name__)
-                print(kiwierr)
-                self._cleanup()
-                sys.exit(1)
-
-        # run kiwi here with "appliance_init" which is a ".kiwi" file
-        os.system("ls -lah")
-
-        print(self._repos)
-
-        self._cleanup()

--- a/src/berry_mill/localwrap.py
+++ b/src/berry_mill/localwrap.py
@@ -1,23 +1,8 @@
 from typing import Dict
 from kiwi.tasks.system_build import SystemBuildTask
-
-import os
 import logging
-from itertools import zip_longest
-
-# project
-from kiwi.help import Help
-from kiwi.system.prepare import SystemPrepare
-from kiwi.system.setup import SystemSetup
-from kiwi.builder import ImageBuilder
-from kiwi.system.profile import Profile
-from kiwi.defaults import Defaults
-from kiwi.privileges import Privileges
-from kiwi.path import Path
 
 log = logging.getLogger('kiwi')
-
-
 
 class LocalBuildTask(SystemBuildTask):
     """

--- a/src/berry_mill/mill.py
+++ b/src/berry_mill/mill.py
@@ -2,12 +2,12 @@ import argparse
 import sys
 import os
 import yaml
-from platform import machine
 
 from berry_mill.cfgh import ConfigHandler, Autodict
-from berry_mill.kiwrap import KiwiBuilder
 from berry_mill.localrepos import DebianRepofind
 from berry_mill.sysinfo import get_local_arch
+from berry_mill.preparer import KiwiPreparer
+from berry_mill.builder import KiwiBuilder
 
 class ImageMill:
     """
@@ -22,21 +22,36 @@ class ImageMill:
         if len(sys.argv) == 1:
             sys.argv.append("--help")
 
-        p:argparse.ArgumentParser = argparse.ArgumentParser(prog="imagemill",
-                                                            description="imagemill is a root filesystem generator for embedded devices",
+        p:argparse.ArgumentParser = argparse.ArgumentParser(prog="berrymill",
+                                                            description="berrymill is a root filesystem generator for embedded devices",
                                                             epilog="Have a lot of fun!")
-        p.add_argument("-c", "--config", type=str, help="specify configuration other than default")
+        
         p.add_argument("-s", "--show-config", action="store_true", help="shows the building configuration")
         p.add_argument("-d", "--debug", action="store_true", help="turns on verbose debugging mode")
         p.add_argument("-a", "--arch", help="specify target arch")
-        p.add_argument("-i", "--image", help="path to the image appliance, if it is not found in the current directory")
-        p.add_argument("-l", "--local", action="store_true", help="build the appliance directly on the current hardware")
+        p.add_argument("-c", "--config", type=str, help="specify configuration other than default")
+        p.add_argument("-i", "--image", required=True, help="path to the image appliance, if it is not found in the current directory")
         p.add_argument("-p", "--profile", help="select profile for images that makes use of it")
-        p.add_argument("--box-memory", type=str, default="8G", help="specify main memory to use for the QEMU VM (box)")
         p.add_argument("--clean", action="store_true", help="cleanup previous build results prior build.")
-        p.add_argument("--cpu", help="cpu to use for the QEMU VM (box)")
-        p.add_argument("--target-dir", type=str, default="/tmp", help="store image results in given dirpath")
-        p.add_argument("--cross", action="store_true", help="cross image build on x86_64 to aarch64 target")
+
+        sub_p = p.add_subparsers(help="Course of action for berrymill",dest="subparser_name")
+        
+        prepare_p:argparse.ArgumentParser= sub_p.add_parser("prepare", help="prepare sysroot")
+        prepare_p.add_argument("--root", required=True, help="directory of output sysroot")
+        prepare_p.add_argument("--allow-existing-root", action="store_true", help="allow existing root")
+
+        build_p:argparse.ArgumentParser = sub_p.add_parser("build", help="build image")
+        build_p.add_argument("--box-memory", type=str, default="8G", help="specify main memory to use for the QEMU VM (box)")
+
+        # --cross sets a cpu -> dont allow user to choose cpu when cross is enabled
+        cpu_group = build_p.add_mutually_exclusive_group()
+        cpu_group.add_argument("--cpu", help="cpu to use for the QEMU VM (box)")
+        cpu_group.add_argument("--cross", action="store_true", help="cross image build on x86_64 to aarch64 target")
+
+        build_p.add_argument("--target-dir", required=True, type=str, help="store image results in given dirpath")
+        build_p.add_argument("-l", "--local", action="store_true", help="build image on current hardware")
+        build_p.add_argument("--no-accel", action="store_true", help="disable KVM acceleration for boxbuild")
+
 
         self.args:argparse.Namespace = p.parse_args()
 
@@ -63,6 +78,9 @@ class ImageMill:
         """
         Initialise local repositories, those are already configured on the local machine.
         """
+        if not self.cfg.raw_unsafe_config().get("use-global-repos", False): 
+            return
+
         if self.cfg.raw_unsafe_config()["repos"].get("local") is not None:
             return
         else:
@@ -81,7 +99,7 @@ class ImageMill:
         Build an image
         """
 
-        # self._init_local_repos()
+        self._init_local_repos()
 
         if self.args.show_config:
             print(yaml.dump(self.cfg.config))
@@ -94,18 +112,39 @@ class ImageMill:
             os.chdir(self._appliance_path)
 
 
-        b = KiwiBuilder(self._appliance_descr, 
-                        box_memory= self.args.box_memory, 
-                        profile= self.args.profile, 
-                        debug=self.args.debug, 
-                        clean= self.args.clean,
-                        cross= self.args.cross,
-                        cpu= self.args.cpu,
-                        local= self.args.local,
-                        target_dir= self.args.target_dir
-                        )
+
+        if self.args.subparser_name == "build":
+            kiwip = KiwiBuilder(self._appliance_descr, 
+                            box_memory= self.args.box_memory, 
+                            profile= self.args.profile, 
+                            debug=self.args.debug, 
+                            clean= self.args.clean,
+                            cross= self.args.cross,
+                            cpu= self.args.cpu,
+                            local= self.args.local,
+                            target_dir= self.args.target_dir,
+                            accel= self.args.no_accel                          
+                            )
+        elif self.args.subparser_name == "prepare":           
+            kiwip = KiwiPreparer(self._appliance_descr,
+                            root=self.args.root,
+                            debug=self.args.debug,
+                            profile=self.args.profile,
+                            allow_existing_root=self.args.allow_existing_root
+                            )
+        else:
+            raise argparse.ArgumentError(message="No Action defined (build, prepare)")
+        
+        # parameter "cross" implies a amd64 host and an arm64 target-arch 
         for r in self.cfg.config["repos"]:
             for rname, repo in (self.cfg.config["repos"][r].get(self.args.arch or get_local_arch()) or {}).items():
-                b.add_repo(rname, repo)
+                kiwip.add_repo(rname, repo)
 
-        b.build()
+        try:
+            kiwip.process()
+        except Exception as err:
+            print(err)
+        finally:
+            kiwip.cleanup()
+
+

--- a/src/berry_mill/params.py
+++ b/src/berry_mill/params.py
@@ -1,0 +1,47 @@
+from typing import TypedDict
+
+
+class KiwiParams(TypedDict):
+    """
+    Dictionary for Kiwi Parameters
+
+    Attributes:
+
+        profile (str, Optional): select profile for images that makes use of it.
+        debug (bool, Default: False): run in debug mode. This means the box VM stays open and the kiwi log level is set to debug(10).
+    """
+    profile: str
+    debug: bool
+
+class KiwiBuildParams(KiwiParams):
+    """
+    Dictionary for Kiwi Parameters
+
+    Attributes:
+
+        box_memory (str, Default: 8G): specify main memory to use for the QEMU VM (box).
+        clean (bool, Default: False): cleanup previous build results prior build.
+        cross (bool, Default: False): cross image build on x86_64 to aarch64 target.
+        cpu (str, Optional): cpu to use for the QEMU VM (box)
+        local (bool, Default: False): run build process locally on this machine. Requires sudo setup and installed KIWI toolchain.
+        target_dir (str, Default:/tmp/IMAGE_NAME[.PROFILE_NAME]): store image results in given dirpath.
+    """
+    box_memory: str
+    clean: bool
+    cross: bool
+    cpu: str
+    local: bool
+    target_dir: str
+    accel: bool
+
+class KiwiPrepParams(KiwiParams):
+    """
+    Dictionary for Kiwi Parameters
+
+    Attributes:
+
+        root (str, Required): Path to create the new root system.
+    """
+    root: str
+    allow_existing_root: bool
+

--- a/src/berry_mill/preparer.py
+++ b/src/berry_mill/preparer.py
@@ -1,0 +1,36 @@
+from typing import Dict, List, Union
+from typing_extensions import Unpack
+from berry_mill.kiwiapp import KiwiAppPrepare
+from berry_mill.kiwrap import KiwiParent
+from berry_mill.params import KiwiPrepParams
+
+
+class KiwiPreparer(KiwiParent):
+    def __init__(self, descr:str, **kw: Unpack[KiwiPrepParams]):
+        self._params:Dict[KiwiPrepParams] = kw
+
+        super().__init__(descr=descr,
+                        profile=self._params.get("profile"),
+                        debug=self._params.get("debug", False))
+    
+    def process(self) -> None:
+        root:Union[str,None] = self._params.get("root")
+
+        assert root is not None
+
+        command:List[str] = ["kiwi-ng"] + self._kiwi_options + ["system", "prepare"]
+        command += ["--description", self._appliance_path]
+        command += ["--root", root]
+
+        if self._params.get("allow_existing_root", False):
+            command.append("--allow-existing-root")
+
+        KiwiAppPrepare(command, repos=self._repos).run()
+
+    def cleanup(self) -> None:
+        # Nothing to clean up
+        super().cleanup()
+
+        if not self._initialized:
+            print("Cleanup finished")
+            return

--- a/src/berry_mill/preparetask.py
+++ b/src/berry_mill/preparetask.py
@@ -1,0 +1,43 @@
+from typing import Dict
+from kiwi.tasks.system_prepare import SystemPrepareTask
+import logging
+
+log = logging.getLogger('kiwi')
+
+class PrepareTask(SystemPrepareTask):
+    """
+    Wrapper Class
+    Overloads load_xml_description(...).
+    Method is expanded to directly alter the xml state 
+    in order to inject the in berrymill.conf defined repositories
+
+    """
+    def __init__(self, repos:Dict[str, Dict[str,str]]) -> None:
+        super().__init__()
+        self.repos:Dict[str, Dict[str,str]] = repos
+
+    
+    def load_xml_description(self, description_directory: str, kiwi_file: str = '') -> None:
+        super().load_xml_description(description_directory, kiwi_file)
+        
+        self.xml_state.delete_repository_sections()
+        for reponame in self.repos:
+
+            repodata:Dict[str,str] = self.repos.get(reponame)
+
+            components = repodata.get("components", "/")
+            components = components if components != '/' else None
+            if components:
+                components = components.replace(",", " ")
+            distro = repodata.get("name", None)
+            print(repodata.get("key"))
+            self.xml_state.add_repository(
+                repo_source=repodata.get("url"),
+                repo_type=repodata.get("type"),
+                repo_alias=reponame,
+                repo_signing_keys=[repodata.get("key")],
+                components=components,
+                distribution=distro,
+                repo_gpgcheck=False
+            )
+

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -1,0 +1,172 @@
+
+from _pytest.capture import CaptureFixture
+import unittest.mock
+from berry_mill.builder import KiwiBuilder
+import requests
+import pytest
+
+
+
+def test_kiwrap_get_relative_file_uri(self):
+        """
+        Test: get_relative_file_uri without key directory defined
+        Expected: Exception Repository data not defined
+        """
+        try:
+            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
+            # Define some test data
+            repo_key_path: str = "path/to/key"
+            KiwiBuilder_instance._boxtmpkeydir: str = ""
+
+            KiwiBuilder_instance._get_relative_file_uri(repo_key_path)
+        except Exception as e:
+            assert "Key directory not available" in str(e)
+
+def test_kiwrap_get_relative_file_uri(self):
+        """
+        Test: get_relative_file_uri without key directory defined
+        Expected: Exception Repository data not defined
+        """
+        try:
+            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
+            # Define some test data
+            repo_key_path: str = ""
+            KiwiBuilder_instance._boxtmpkeydir: str = "/tmp"
+
+            KiwiBuilder_instance._get_relative_file_uri(repo_key_path)
+        except Exception as e:
+            assert "Key path not defined" in str(e)
+
+
+def test_kiwrap_write_repokeys_wrong_key_path(self, capsys: CaptureFixture):
+        """
+        Write repo keys while wrong key path in config
+        Expected : exit code 1 exception and error failure message
+        """
+        try:
+            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
+            # Define some test data
+            reponame: str = "test"
+            repodata: dict = {"name": "test", "url": "https://www.example.com", "key": "file:///wrong/path"}
+            repo = {reponame: repodata}
+
+            KiwiBuilder_instance._write_repokeys_box(repo)
+            # Capture the error message printed on stdout
+            captured: tuple = capsys.readouterr()
+            # Assert that the error message contains the expected error message
+            assert "Failure while trying to copying the keyfile" in captured.out
+        except SystemExit as e:
+            assert e.code == 1
+
+def test_kiwrap_write_repokeys_box_root_dest(self):
+        """
+        Write repo keys from tmp dir to a wrong boxroot destination
+        Expected: exit code 1 and Boxroot directory is not defined exception
+        """
+        try:
+            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
+            # Override tmp box root directory destination path
+            KiwiBuilder_instance._boxtmpkeydir: str = ""
+            # Define some test data
+            reponame: str = "test"
+            repodata: dict = {"name": "test", "url": "https://www.example.com", "key": "file:///wrong/path"}
+            repo = {reponame: repodata}
+
+            KiwiBuilder_instance._write_repokeys_box(repo)
+        except SystemExit as e:
+            assert e.code == 1
+        except Exception as ex:
+            assert "Boxroot directory is not defined" in str(ex)
+
+def test_kiwrap__cleanup_no_tmpdir(self, capsys: CaptureFixture):
+        """
+        Write repo keys from tmp dir to a wrong boxroot destination
+        Expected: Error Cleanup Failed
+        """
+
+        KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
+        # Set tmpdir to empty
+        KiwiBuilder_instance._tmpdir: str = ""
+
+        KiwiBuilder_instance.cleanup()
+        # Capture the error message printed on stdout
+        captured: tuple = capsys.readouterr()
+        # Assert that the error message contains the expected error message
+        assert "Error: Cleanup Failed" in captured.out
+
+def test_kiwrap_cleanup_no_boxtmpdiraaa(self, capsys: CaptureFixture):
+        """
+        Write repo keys from tmp dir to a wrong boxroot destination
+        Expected: Error Cleanup Failed
+        """
+        KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
+        # Set tmpdir
+        KiwiBuilder_instance._tmpdir: str = "/tmp"
+        # Set wrok box tmp dir
+        KiwiBuilder_instance._boxtmpkeydir: str = "worng/path"
+        KiwiBuilder_instance.cleanup()
+        # Capture the error message printed on stdout
+        captured: tuple = capsys.readouterr()
+        assert "Error: Cleanup Failed" in captured.out
+
+def test_kiwrap_build_wrong_appliance(self, capsys: CaptureFixture):
+        """
+        Parse wrong appliance
+        Expected: exit 1 and error Expected: failed to load external entity
+        """
+        try:
+            # Create KiwiBuilder instance with wrong appliance
+            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
+            # trigger the build
+            KiwiBuilder_instance.process()
+        except SystemExit as se:
+            cap: tuple = capsys.readouterr()
+            assert "failed to load external entity" in cap.out
+            assert se.code == 1
+
+def test_kiwrap_build_no_profile_set(self, capsys: CaptureFixture):
+        """
+        Test config no profie
+        Expected: exit 1 and error Expected: No Profile selected
+        """
+        try:
+            # Create KiwiBuilder instance with existant appliance
+            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test/test_appliance.xml")
+            # Remove profile
+            KiwiBuilder_instance._params["profile"] = ""
+            # Trigger the build
+            KiwiBuilder_instance.process()
+            captured: tuple = capsys.readouterr()
+            assert "No Profile selected" in captured.out
+        except SystemExit as se:
+            assert se.code == 1
+
+@pytest.mark.skip(reason="Dependency to berrymill package not yet ready")
+def test_kiwrap_build_with_profile_set(self, capsys: CaptureFixture):
+        """
+        Test config  profie is
+        Expected: message "Starting Kiwi Box"
+        """
+        KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test/test_appliance.xml")
+        # Set profile
+        KiwiBuilder_instance._params["profile"] = "Live"
+        KiwiBuilder_instance.process()
+        captured: tuple = capsys.readouterr()
+        assert "Starting Kiwi Box" in captured.out
+
+def test_kiwrap_build_with_local_set(self, capsys: CaptureFixture):
+        """
+        Test config  profie is
+        Expected: message "Starting Kiwi for local build"
+        """
+        try:
+            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test/test_appliance.xml")
+            # Set profile
+            KiwiBuilder_instance._params["profile"] = "Live"
+            # Set local build
+            KiwiBuilder_instance._params["local"] = True
+            KiwiBuilder_instance.process()
+            captured: tuple = capsys.readouterr()
+            assert "Starting Kiwi for local build" in captured.out
+        except SystemExit as e:
+            print("Ignoring root permission error")

--- a/test/test_kiwrap.py
+++ b/test/test_kiwrap.py
@@ -1,7 +1,8 @@
 
 from _pytest.capture import CaptureFixture
 import unittest.mock
-from berry_mill.kiwrap import KiwiBuilder
+from berry_mill.builder import KiwiBuilder
+from berry_mill.kiwrap import KiwiParent
 import requests
 import pytest
 
@@ -16,24 +17,24 @@ class TestCollectionKiwiBuilder:
         """
         Verify that repo name and repo data: url, key, type.. are added correctly
         """
-        KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
+        KiwiParent_instance: KiwiParent = KiwiParent("test.txt")
         # Define some test data
         reponame: str = "test_repo"
         repodata: dict = {"name": "repo", "url": "http://test.com"}
 
         # Mock _get_repokeys a,d _check_repokeys method
-        with unittest.mock.patch.object(KiwiBuilder_instance, "_get_repokeys") as mock_get_repokey:
+        with unittest.mock.patch.object(KiwiParent_instance, "_get_repokeys") as mock_get_repokey:
             # Mock the _check_repokeys method """
-            with unittest.mock.patch.object(KiwiBuilder_instance, "_check_repokey") as mock_check_repokey:
+            with unittest.mock.patch.object(KiwiParent_instance, "_check_repokey") as mock_check_repokey:
                 # Mock _get_repokey to skip callby returning test.key file path
                 mock_get_repokey.return_value: str = "test.key"
                 # Mock _check_repokey to skip callby returning 0
                 mock_check_repokey.return_value: int = 0
                 # Add reponame and repodata with add_repo
-                KiwiBuilder_instance.add_repo(reponame, repodata)
+                KiwiParent_instance.add_repo(reponame, repodata)
                 # Check repodatas added correctly
-                assert reponame in KiwiBuilder_instance._repos
-                assert KiwiBuilder_instance._repos[reponame] == repodata
+                assert reponame in KiwiParent_instance._repos
+                assert KiwiParent_instance._repos[reponame] == repodata
 
     def test_kiwrap_add_repo_no_url(self):
         """
@@ -41,11 +42,11 @@ class TestCollectionKiwiBuilder:
         Expected : Exception URL not found
         """
         try:
-            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
+            KiwiParent_instance: KiwiParent = KiwiParent("test.txt")
             # Define some test data
             reponame: str = "test_repo"
             repodata: dict = {"name": "repo", "url": ""}
-            KiwiBuilder_instance.add_repo(reponame, repodata)
+            KiwiParent_instance.add_repo(reponame, repodata)
         except Exception as e:
             assert "URL not found" in str(e)
 
@@ -57,11 +58,11 @@ class TestCollectionKiwiBuilder:
           Exit code 1
         """
         try:
-            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
+            KiwiParent_instance: KiwiParent = KiwiParent("test.txt")
             # Define some test data
             reponame: str = ""
             repodata: dict = {"name": "test", "url": "http://test.com"}
-            KiwiBuilder_instance.add_repo(reponame, repodata)
+            KiwiParent_instance.add_repo(reponame, repodata)
             # Capture the error message printed on stdout
             captured: tuple = capsys.readouterr()
             # Assert that the error message contains the expected error message
@@ -75,11 +76,11 @@ class TestCollectionKiwiBuilder:
         Expected: Exception URL not found
         """
         try:
-            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
+            KiwiParent_instance: KiwiParent = KiwiParent("test.txt")
             # Define some test data
             reponame: str = "test_repo"
             repodata: dict = {"name": "test", "url": ""}
-            KiwiBuilder_instance._get_repokeys(reponame, repodata)
+            KiwiParent_instance._get_repokeys(reponame, repodata)
         except Exception as e:
             assert "URL not found" in str(e)
 
@@ -89,11 +90,11 @@ class TestCollectionKiwiBuilder:
         Expected: Exception o connection adapters were found
         """
         try:
-            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
+            KiwiParent_instance: KiwiParent = KiwiParent("test.txt")
             # Define some test data
             reponame: str = "test_repo"
             repodata: dict = {"name": "test", "url": "no_schema"}
-            KiwiBuilder_instance._get_repokeys(reponame, repodata)
+            KiwiParent_instance._get_repokeys(reponame, repodata)
         except requests.exceptions.InvalidSchema as e:
             assert "No connection adapters were found" in str(e)
 
@@ -103,12 +104,12 @@ class TestCollectionKiwiBuilder:
         Expected: Exception Repository name not defined
         """
         try:
-            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
+            KiwiParent_instance: KiwiParent = KiwiParent("test.txt")
             # Define some test data
             reponame: str = ""
             repodata: dict = {"name": "test", "url": "http://test"}
 
-            KiwiBuilder_instance._get_repokeys(reponame, repodata)
+            KiwiParent_instance._get_repokeys(reponame, repodata)
         except Exception as e:
             assert "Repository name not defined" in str(e)
 
@@ -118,44 +119,14 @@ class TestCollectionKiwiBuilder:
         Expected: Exception Repository data not defined
         """
         try:
-            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
+            KiwiParent_instance: KiwiParent = KiwiParent("test.txt")
             # Define some test data
             reponame: str = "test_repo"
             repodata: dict = {}
 
-            KiwiBuilder_instance._get_repokeys(reponame, repodata)
+            KiwiParent_instance._get_repokeys(reponame, repodata)
         except Exception as e:
             assert "Repository data not defined" in str(e)
-
-    def test_kiwrap_get_relative_file_uri(self):
-        """
-        Test: get_relative_file_uri without key directory defined
-        Expected: Exception Repository data not defined
-        """
-        try:
-            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
-            # Define some test data
-            repo_key_path: str = "path/to/key"
-            KiwiBuilder_instance._boxtmpkeydir: str = ""
-
-            KiwiBuilder_instance._get_relative_file_uri(repo_key_path)
-        except Exception as e:
-            assert "Key directory not available" in str(e)
-
-    def test_kiwrap_get_relative_file_uri(self):
-        """
-        Test: get_relative_file_uri without key directory defined
-        Expected: Exception Repository data not defined
-        """
-        try:
-            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
-            # Define some test data
-            repo_key_path: str = ""
-            KiwiBuilder_instance._boxtmpkeydir: str = "/tmp"
-
-            KiwiBuilder_instance._get_relative_file_uri(repo_key_path)
-        except Exception as e:
-            assert "Key path not defined" in str(e)
 
     def test_kiwrap_check_repokey_no_key(self):
         """
@@ -163,12 +134,12 @@ class TestCollectionKiwiBuilder:
         Expected: Exception Repository data not defined
         """
         try:
-            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
+            KiwiParent_instance: KiwiParent = KiwiParent("test.txt")
             # Define some test data
             reponame: str = "test"
             repodata: dict = {"name": "test", "url": "http://test", "key": ""}
 
-            KiwiBuilder_instance._check_repokey(repodata, reponame)
+            KiwiParent_instance._check_repokey(repodata, reponame)
         except Exception as e:
             assert "Path to the key is not defined" in str(e)
 
@@ -179,13 +150,13 @@ class TestCollectionKiwiBuilder:
         Expected: Berrymill was not able to retrieve a fitting gpg key
         """
 
-        KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
-        with unittest.mock.patch.object(KiwiBuilder_instance, "_key_selection") as mock_key_selection:
+        KiwiParent_instance: KiwiParent = KiwiParent("test.txt")
+        with unittest.mock.patch.object(KiwiParent_instance, "_key_selection") as mock_key_selection:
             # Define some test data
             reponame: str = "test"
             repodata: dict = {"name": "test", "url": "http://test", "key": "file://"}
             mock_key_selection.return_value = ""
-            KiwiBuilder_instance._check_repokey(repodata, reponame)
+            KiwiParent_instance._check_repokey(repodata, reponame)
             # Capture the error message printed on stdout
             captured: tuple = capsys.readouterr()
             # Assert that the error message contains the expected error message
@@ -197,151 +168,19 @@ class TestCollectionKiwiBuilder:
         Expected: Trusted key not foud on system
         """
 
-        KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
+        KiwiParent_instance: KiwiParent = KiwiParent("test.txt")
 
-        with unittest.mock.patch.object(KiwiBuilder_instance, "_key_selection") as mock_key_selection:
+        with unittest.mock.patch.object(KiwiParent_instance, "_key_selection") as mock_key_selection:
             # Define some test data
             reponame: str = "test"
             repodata: dict = {"name": "test", "url": "http://test", "key": "file://"}
             # Disable selection menu
             mock_key_selection.return_value = ""
             # Redirect for non existent dir
-            KiwiBuilder_instance._trusted_gpg_d = "/wrong/path"
-            KiwiBuilder_instance._check_repokey(repodata, reponame)
+            KiwiParent_instance._trusted_gpg_d = "/wrong/path"
+            KiwiParent_instance._check_repokey(repodata, reponame)
             # Capture the error message printed on stdout
             captured: tuple = capsys.readouterr()
             # Assert that the error message contains the expected error message
             assert "Trusted key not foud on system" in captured.out
 
-    def test_kiwrap_write_repokeys_wrong_key_path(self, capsys: CaptureFixture):
-        """
-        Write repo keys while wrong key path in config
-        Expected : exit code 1 exception and error failure message
-        """
-        try:
-            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
-            # Define some test data
-            reponame: str = "test"
-            repodata: dict = {"name": "test", "url": "https://www.example.com", "key": "file:///wrong/path"}
-            repo = {reponame: repodata}
-
-            KiwiBuilder_instance._write_repokeys_box(repo)
-            # Capture the error message printed on stdout
-            captured: tuple = capsys.readouterr()
-            # Assert that the error message contains the expected error message
-            assert "Failure while trying to copying the keyfile" in captured.out
-        except SystemExit as e:
-            assert e.code == 1
-
-    def test_kiwrap_write_repokeys_box_root_dest(self):
-        """
-        Write repo keys from tmp dir to a wrong boxroot destination
-        Expected: exit code 1 and Boxroot directory is not defined exception
-        """
-        try:
-            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
-            # Override tmp box root directory destination path
-            KiwiBuilder_instance._boxtmpkeydir: str = ""
-            # Define some test data
-            reponame: str = "test"
-            repodata: dict = {"name": "test", "url": "https://www.example.com", "key": "file:///wrong/path"}
-            repo = {reponame: repodata}
-
-            KiwiBuilder_instance._write_repokeys_box(repo)
-        except SystemExit as e:
-            assert e.code == 1
-        except Exception as ex:
-            assert "Boxroot directory is not defined" in str(ex)
-
-    def test_kiwrap__cleanup_no_tmpdir(self, capsys: CaptureFixture):
-        """
-        Write repo keys from tmp dir to a wrong boxroot destination
-        Expected: Error Cleanup Failed
-        """
-
-        KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
-        # Set tmpdir to empty
-        KiwiBuilder_instance._tmpdir: str = ""
-
-        KiwiBuilder_instance._cleanup()
-        # Capture the error message printed on stdout
-        captured: tuple = capsys.readouterr()
-        # Assert that the error message contains the expected error message
-        assert "Error: Cleanup Failed" in captured.out
-
-    def test_kiwrap_cleanup_no_boxtmpdiraaa(self, capsys: CaptureFixture):
-        """
-        Write repo keys from tmp dir to a wrong boxroot destination
-        Expected: Error Cleanup Failed
-        """
-        KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
-        # Set tmpdir
-        KiwiBuilder_instance._tmpdir: str = "/tmp"
-        # Set wrok box tmp dir
-        KiwiBuilder_instance._boxtmpkeydir: str = "worng/path"
-        KiwiBuilder_instance._cleanup()
-        # Capture the error message printed on stdout
-        captured: tuple = capsys.readouterr()
-        assert "Error: Cleanup Failed" in captured.out
-
-    def test_kiwrap_build_wrong_appliance(self, capsys: CaptureFixture):
-        """
-        Parse wrong appliance
-        Expected: exit 1 and error Expected: failed to load external entity
-        """
-        try:
-            # Create KiwiBuilder instance with wrong appliance
-            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test.txt")
-            # trigger the build
-            KiwiBuilder_instance.build()
-        except SystemExit as se:
-            cap: tuple = capsys.readouterr()
-            assert "failed to load external entity" in cap.out
-            assert se.code == 1
-
-    def test_kiwrap_build_no_profile_set(self, capsys: CaptureFixture):
-        """
-        Test config no profie
-        Expected: exit 1 and error Expected: No Profile selected
-        """
-        try:
-            # Create KiwiBuilder instance with existant appliance
-            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test/test_appliance.xml")
-            # Remove profile
-            KiwiBuilder_instance._params["profile"] = ""
-            # Trigger the build
-            KiwiBuilder_instance.build()
-            captured: tuple = capsys.readouterr()
-            assert "No Profile selected" in captured.out
-        except SystemExit as se:
-            assert se.code == 1
-
-    @pytest.mark.skip(reason="Dependency to berrymill package not yet ready")
-    def test_kiwrap_build_with_profile_set(self, capsys: CaptureFixture):
-        """
-        Test config  profie is
-        Expected: message "Starting Kiwi Box"
-        """
-        KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test/test_appliance.xml")
-        # Set profile
-        KiwiBuilder_instance._params["profile"] = "Live"
-        KiwiBuilder_instance.build()
-        captured: tuple = capsys.readouterr()
-        assert "Starting Kiwi Box" in captured.out
-
-    def test_kiwrap_build_with_local_set(self, capsys: CaptureFixture):
-        """
-        Test config  profie is
-        Expected: message "Starting Kiwi for local build"
-        """
-        try:
-            KiwiBuilder_instance: KiwiBuilder = KiwiBuilder("test/test_appliance.xml")
-            # Set profile
-            KiwiBuilder_instance._params["profile"] = "Live"
-            # Set local build
-            KiwiBuilder_instance._params["local"] = True
-            KiwiBuilder_instance.build()
-            captured: tuple = capsys.readouterr()
-            assert "Starting Kiwi for local build" in captured.out
-        except SystemExit as e:
-            print("Ignoring root permission error")


### PR DESCRIPTION
Major reworks:

-      Improved Parameter parsing
-      Added Subparser (build, prepare)
-      Support for kiwi-ng system prepare
-      Added no-accel for boxbuilding
-      Added allow-existing-root for prepare
-      minimize reduntant code with better inheritance
-      Introduced class KiwiParent for kiwi Repo Handling
-      Split classes in differnt files
-      Unit Test adjustemnt to follow to new code layout
-      config enhancement: Useful config