### PR TITLE
fail early if target-dir exists without --clean option

### DIFF
--- a/src/berry_mill/mill.py
+++ b/src/berry_mill/mill.py
@@ -81,6 +81,10 @@ class ImageMill:
         Build an image
         """
 
+        # if target_dir exists with no --clean option, fail early.
+        if not self.args.clean and os.path.isdir(self.args.target_dir):
+            raise Exception("Target directory already exists. Missed --clean ?")
+
         # self._init_local_repos()
 
         if self.args.show_config:

--- a/src/berry_mill/mill.py
+++ b/src/berry_mill/mill.py
@@ -83,7 +83,11 @@ class ImageMill:
 
         # if target_dir exists with no --clean option, fail early.
         if not self.args.clean and os.path.isdir(self.args.target_dir):
-            raise Exception("Target directory already exists. Missed --clean ?")
+            raise Exception("Target directory already exists. Hint: use --clean option.")
+
+        # parent directory should be writable
+        if not os.access(os.path.dirname(self.args.target_dir), os.W_OK):
+            raise Exception("Target directory's parent is not writable, please use writable directory")
 
         # self._init_local_repos()
 


### PR DESCRIPTION
fail early if target-dir exists without --clean option, or it's not in a writable directory.