### PR TITLE
Fix os.access(W_OK) check for none existing target_dir

### DIFF
--- a/src/berry_mill/kiwrap.py
+++ b/src/berry_mill/kiwrap.py
@@ -145,7 +145,8 @@ class KiwiParent:
                           ),
         ]
         answer = inquirer.prompt(question)
-        log.info("You selected:", answer["choice"])
+        # Logging wont work here 
+        print("You selected:", answer["choice"])
 
         return answer["choice"] != none_of_above and answer["choice"] or None
 

--- a/test/test_targetdir.py
+++ b/test/test_targetdir.py
@@ -1,24 +1,17 @@
 import unittest
 from unittest.mock import patch
+
+from pytest import LogCaptureFixture
+import kiwi.logger
 from berry_mill.builder import KiwiBuilder
 
-class TestTargetDir(unittest.TestCase):
+class TestTargetDir:
 
     @patch("os.path.isdir", lambda f: True)
     @patch("berry_mill.kiwiapp.KiwiAppLocal.run", lambda f: True)
-    def test_dir_exist(self):
-        with self.assertRaises (Exception) as msg:
+    def test_dir_exist(self, caplog: LogCaptureFixture):
+        with caplog.at_level(kiwi.logging.ERROR):
             kb: KiwiBuilder = KiwiBuilder("test/descr/test_appliance.xml", profile="Live", target_dir="/arbitrary/dir")
             kb.process()
-        self.assertTrue("Target directory already exists" in str(msg.exception))
-
-    @patch("os.access")
-    @patch("berry_mill.kiwiapp.KiwiAppLocal.run", lambda f: True)
-    def test_dir_readonly(self, mock_os_access):
-        with self.assertRaises (Exception) as msg:
-            mock_os_access.return_value = False
-            kb: KiwiBuilder = KiwiBuilder("test/descr/test_appliance.xml", profile="Live", target_dir="/arbitrary/dir")
-            kb.process()
-        self.assertTrue("Target directory's parent is not writable" in str(msg.exception))
-
+        assert "Target directory already exists" in caplog.text
         


### PR DESCRIPTION
After the last merged PRs berrymill is broken...

- The target_dir is created by Kiwi. Kiwi implements the complete logic for this like e.g. if it already exists kiwi will also fail.
- Checking whether the parent dir is writable at the place it was done before this fix, has no impact. It will fail  0,0001 sec faster, which IMHO is irrelevant.
- However we are actively looking for that error now and display an log.error msg accordingly without involving concrete Info that this error is coming from kiwi.