### PR TITLE
fix kvm check

### DIFF
--- a/src/berry_mill/sysinfo.py
+++ b/src/berry_mill/sysinfo.py
@@ -1,6 +1,7 @@
 import platform
 import os
 from typing import Dict
+import shutil
 import kiwi.logger
 
 archfix: Dict[str, str] = {
@@ -23,11 +24,6 @@ def has_virtualization() -> bool:
     """
     Returns True if a nested virtualization checks passed.
     """
-
-    # Intels/AMDs only
-    if platform.processor() != "x86_64":  # also AMD
-        log.error("Only x86_64 architecture is supported at the moment")
-        return False
 
     # CPU supports VM
     with open("/proc/cpuinfo") as fr:
@@ -65,14 +61,12 @@ def is_vm() -> bool:
     """
     Detect if the current machine is a VM
     """
-    lshw:str = "/usr/bin/lshw"
-    assert os.path.exists(lshw), f"{lshw} utility is missing"
-
+    assert shutil.which("lshw"), "lshw utility is missing"
     # Crude test on vendors
     vendors:list[str] = set(filter(None, map(lambda l:l.startswith("vendor:")
                                              and l.split(":")[-1].strip()
                                              or "", [x.strip().lower() for x in
-                                                     os.popen(f"{lshw} 2> /dev/null").readlines()])))
+                                                     os.popen("lshw 2> /dev/null").readlines()])))
     for v in ["qemu", "virtualbox", "vmware"]:
         if v in vendors:
             return True

--- a/src/berry_mill/sysinfo.py
+++ b/src/berry_mill/sysinfo.py
@@ -1,7 +1,6 @@
 import platform
 import os
 from typing import Dict
-import shutil
 import kiwi.logger
 
 archfix: Dict[str, str] = {
@@ -61,7 +60,7 @@ def is_vm() -> bool:
     """
     Detect if the current machine is a VM
     """
-    assert shutil.which("lshw"), "lshw utility is missing"
+    assert bool(list(filter(None, [os.path.exists("{}/lshw".format(p)) for p in ["/usr/bin", "/usr/sbin", "/sbin", "/bin"]]))), "lshw utility is missing"
     # Crude test on vendors
     vendors:list[str] = set(filter(None, map(lambda l:l.startswith("vendor:")
                                              and l.split(":")[-1].strip()


### PR DESCRIPTION
lshw can be located at different path e.g. /usr/sbin. Intel/AMD CPU check doesn't work as expected, not really needed since kvm_amd/intel check already exists afterwards.