### PR TITLE
do not keep box open

### DIFF
--- a/src/berry_mill/builder.py
+++ b/src/berry_mill/builder.py
@@ -111,9 +111,6 @@ class KiwiBuilder(KiwiParent):
         # options, solely accepted by box-build plugin
         box_options:List[str] = ["--box","ubuntu"]
 
-        if self._kiwiparams.get("debug"):
-            box_options.append("--box-debug")
-
         if self._params.get("cpu"):
             box_options = ["--cpu", self._params.get("cpu","")] + box_options
 


### PR DESCRIPTION
The '--box-debug' flag keeps the QEMU box open, which is confusing for image building.