### PR TITLE
Fix derivative

### DIFF
--- a/src/berry_mill/imgdescr/loader.py
+++ b/src/berry_mill/imgdescr/loader.py
@@ -13,8 +13,11 @@ class UqList(list):
 
 
 class Loader:
+    
     def __init__(self) -> None:
         self.__i_stack = UqList()
+        self.is_derived: bool = False
+        self.main_appliance_pth: str = ""
 
     def _traverse(self, pth: str) -> None:
         """
@@ -30,9 +33,11 @@ class Loader:
 
         l_iht:list[ET.Element]|None = ApplianceDescription.find_all("inherit", doc)
         if l_iht:
+            self.is_derived = True
             self.__i_stack.append(next(iter(l_iht)).attrib["path"])
             self._traverse(self.__i_stack[-1])
         else:
+            self.main_appliance_pth = pth
             self.__i_stack.append(pth)
 
     def _flatten(self) -> str:


### PR DESCRIPTION
Only the Appliance.kiwi was correctly generated. 
However e.g. config.sh and the root dir werent considered in the derived image build and consequently the build failed.

SOLUTION:
Symlink to every file inside the directory of the "main" appliance.kiwi. We cannot hard code the files that kiwi needs to create only a few really required symlinks. Kiwi might change the names of the scripts or a user might even define a "user-defined" script in the appliance.kiwi xml description their selves. This can be any name we cannot foresee (at least it would be unnecessarily difficult to do so=.
