### PR TITLE
catch requests exception if key download fails

### DIFF
--- a/src/berry_mill/kiwrap.py
+++ b/src/berry_mill/kiwrap.py
@@ -126,7 +126,7 @@ class KiwiParent:
             try:
                 response = requests.get(s_url, allow_redirects=True)
             except Exception as e:
-                log.warning(f"Download key error: {e}")
+                log.warning(f"Unable to download key: {e}")
                 return None
             # check reponse OK
             if response.status_code == HTTPStatus.OK:

--- a/src/berry_mill/kiwrap.py
+++ b/src/berry_mill/kiwrap.py
@@ -127,6 +127,7 @@ class KiwiParent:
                 response = requests.get(s_url, allow_redirects=True)
             except Exception as e:
                 log.error(f"Download key error: {e}")
+                return None
             # check reponse OK
             if response.status_code == HTTPStatus.OK:
                 with open(g_path, 'xb') as f_rel:

--- a/src/berry_mill/kiwrap.py
+++ b/src/berry_mill/kiwrap.py
@@ -123,7 +123,10 @@ class KiwiParent:
             return g_path
         else:
             s_url = urljoin(f"{url.scheme}://{url.netloc}/{url.path}/Release.key", "")
-            response = requests.get(s_url, allow_redirects=True)
+            try:
+                response = requests.get(s_url, allow_redirects=True)
+            except Exception as e:
+                log.error(f"Download key error: {e}")
             # check reponse OK
             if response.status_code == HTTPStatus.OK:
                 with open(g_path, 'xb') as f_rel:

--- a/src/berry_mill/kiwrap.py
+++ b/src/berry_mill/kiwrap.py
@@ -126,7 +126,7 @@ class KiwiParent:
             try:
                 response = requests.get(s_url, allow_redirects=True)
             except Exception as e:
-                log.error(f"Download key error: {e}")
+                log.warning(f"Download key error: {e}")
                 return None
             # check reponse OK
             if response.status_code == HTTPStatus.OK:


### PR DESCRIPTION
If server is down, requests is throwing an exception which kills the build if it's not catched.

```
[ ERROR   ]: 10:20:32 | Runtime error: HTTPConnectionPool(host='172.17.0.3', port=8000): Max retries exceeded with url: //Release.key (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f204d40faf0>: Failed to establish a new connection: [Errno 113] No route to host'))

Traceback (most recent call last):

  File "/build/venv/lib/python3.10/site-packages/urllib3/connection.py", line 198, in _new_conn

    sock = connection.create_connection(

  File "/build/venv/lib/python3.10/site-packages/urllib3/util/connection.py", line 85, in create_connection

    raise err

  File "/build/venv/lib/python3.10/site-packages/urllib3/util/connection.py", line 73, in create_connection

    sock.connect(sa)

OSError: [Errno 113] No route to host



The above exception was the direct cause of the following exception:



Traceback (most recent call last):

  File "/build/venv/lib/python3.10/site-packages/urllib3/connectionpool.py", line 793, in urlopen

    response = self._make_request(

  File "/build/venv/lib/python3.10/site-packages/urllib3/connectionpool.py", line 496, in _make_request

    conn.request(

  File "/build/venv/lib/python3.10/site-packages/urllib3/connection.py", line 400, in request

    self.endheaders()

  File "/usr/lib/python3.10/http/client.py", line 1278, in endheaders

    self._send_output(message_body, encode_chunked=encode_chunked)

  File "/usr/lib/python3.10/http/client.py", line 1038, in _send_output

    self.send(msg)

  File "/usr/lib/python3.10/http/client.py", line 976, in send

    self.connect()

  File "/build/venv/lib/python3.10/site-packages/urllib3/connection.py", line 238, in connect

    self.sock = self._new_conn()

  File "/build/venv/lib/python3.10/site-packages/urllib3/connection.py", line 213, in _new_conn

    raise NewConnectionError(

urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPConnection object at 0x7f204d40faf0>: Failed to establish a new connection: [Errno 113] No route to host



The above exception was the direct cause of the following exception:



Traceback (most recent call last):

  File "/build/venv/lib/python3.10/site-packages/requests/adapters.py", line 486, in send

    resp = conn.urlopen(

  File "/build/venv/lib/python3.10/site-packages/urllib3/connectionpool.py", line 847, in urlopen

    retries = retries.increment(

  File "/build/venv/lib/python3.10/site-packages/urllib3/util/retry.py", line 515, in increment

    raise MaxRetryError(_pool, url, reason) from reason  # type: ignore[arg-type]

urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='172.17.0.3', port=8000): Max retries exceeded with url: //Release.key (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f204d40faf0>: Failed to establish a new connection: [Errno 113] No route to host'))



During handling of the above exception, another exception occurred:



Traceback (most recent call last):

  File "/build/venv/bin/berrymill", line 8, in <module>

    sys.exit(main())

  File "/build/venv/lib/python3.10/site-packages/berry_mill/__init__.py", line 21, in main

    mill.run()

  File "/build/venv/lib/python3.10/site-packages/berry_mill/mill.py", line 282, in run

    kiwip.add_repo(rname, repo)

  File "/build/venv/lib/python3.10/site-packages/berry_mill/kiwrap.py", line 80, in add_repo

    key_path: str = self._get_repokeys(reponame, repodata)

  File "/build/venv/lib/python3.10/site-packages/berry_mill/kiwrap.py", line 126, in _get_repokeys

    response = requests.get(s_url, allow_redirects=True)

  File "/build/venv/lib/python3.10/site-packages/requests/api.py", line 73, in get

    return request("get", url, params=params, **kwargs)

  File "/build/venv/lib/python3.10/site-packages/requests/api.py", line 59, in request

    return session.request(method=method, url=url, **kwargs)

  File "/build/venv/lib/python3.10/site-packages/requests/sessions.py", line 589, in request

    resp = self.send(prep, **send_kwargs)

  File "/build/venv/lib/python3.10/site-packages/requests/sessions.py", line 703, in send

    r = adapter.send(request, **kwargs)

  File "/build/venv/lib/python3.10/site-packages/requests/adapters.py", line 519, in send

    raise ConnectionError(e, request=request)

requests.exceptions.ConnectionError: HTTPConnectionPool(host='172.17.0.3', port=8000): Max retries exceeded with url: //Release.key (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f204d40faf0>: Failed to establish a new connection: [Errno 113] No route to host'))
```